### PR TITLE
Fix Truncated JSON input during discovery

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -33,7 +33,7 @@ func BroadcastDiscovery(timeout, probes int) (map[string]*Sysinfo, error) {
 		}
 	}()
 
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, 2048)
 	// klogger.Printf("probing %d times in %d seconds (rate: %d)\n", probes, timeout, timeout / (probes + 1) )
 	for {
 		n, addr, err := conn.ReadFromUDP(buffer)


### PR DESCRIPTION
Fixes "unmarshal: unexpected end of JSON input" error for me due to 6 outlet Power strip response larger than 1024

Buffer may need to be increased for other discovery types, but this is the one that I use within my application.