### PR TITLE
Update net error with more details

### DIFF
--- a/net.go
+++ b/net.go
@@ -46,7 +46,7 @@ func (d *Device) sendTCP(cmd string) ([]byte, error) {
 		return nil, err
 	}
 	if n != int(size) {
-		err := fmt.Errorf("not all bytes read: %d/%d, %s", n, size, data)
+		err := fmt.Errorf("not all bytes read from host %s: %d/%d, %s", d.parsed, n, size, Unscramble(data))
 		klogger.Printf(err.Error())
 		return nil, err
 	}


### PR DESCRIPTION
Added the IP address to the error so we know which host the error came from. 
Also added a call to Unscramble  so that the data we do get might be a a little more helpful for debugging

# Example Log line produced

```
2022/04/04 22:49:20 not all bytes read from host X.X.X.XX: 1020/1166, {"system":{"get_sysinfo":{"sw_ver":"1.0.19 Build 200224 Rel.090814","hw_ver":"1.0","model":"HS300(US)","deviceId":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX","oemId":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX","hwId":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX","rssi":-55,"longitude_i":0,"latitude_i":0,"alias":"Faulty Strip","status":"new","mic_type":"IOT.SMARTPLUGSWITCH","feature":"TIM:ENE","mac":"XX:XX:XX:XX:XX:XX","updating":0,"led_off":0,"children":[{"id":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX0","state":1,"alias":"","on_time":44099,"next_action":{"type":-1}},{"id":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1","state":1,"alias":"","on_time":43799,"next_action":{"type":-1}},{"id":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX2","state":1,"alias":"","on_time":43799,"next_action":{"type":-1}},{"id":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX3","state":1,"alias":"","on_time":43499,"next_action":{"type":-1}},{"id":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX4","state":1,"alias":"","on_time":44099,"next_action":{"type":
```